### PR TITLE
[#60] 롤링 페이퍼 리스트 페이지 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,7 @@ import GlobalStyle from '@/styles/GlobalStyle.js';
 import Post from '@/pages/Post.jsx';
 import Main from '@/pages/Main.jsx';
 import Nav from '@/components/Nav/Nav.jsx';
-import FromPage from './pages/FromPage';
+import From from '@/pages/FromPage';
 
 function App() {
   return (
@@ -16,7 +16,7 @@ function App() {
         <Route path="/post" element={<Post />}>
           <Route path=":postId" element={<Post />} />
         </Route>
-        <Route path="/from" element={<FromPage />} />
+        <Route path="/from" element={<From />} />
       </Routes>
     </div>
   );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,7 @@ import GlobalStyle from '@/styles/GlobalStyle.js';
 import Post from '@/pages/Post.jsx';
 import Main from '@/pages/Main.jsx';
 import Nav from '@/components/Nav/Nav.jsx';
-import From from '@/pages/FromPage';
+import From from '@/pages/From.jsx';
 
 function App() {
   return (

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import Post from '@/pages/Post.jsx';
 import Main from '@/pages/Main.jsx';
 import Nav from '@/components/Nav/Nav.jsx';
 import From from '@/pages/From.jsx';
+import PaperList from '@/pages/PaperList.jsx';
 
 function App() {
   return (
@@ -12,7 +13,7 @@ function App() {
       <Nav />
       <Routes>
         <Route path="/" element={<Main />} />
-        <Route path="/list" element={<Main />} />
+        <Route path="/list" element={<PaperList />} />
         <Route path="/post" element={<Post />}>
           <Route path=":postId" element={<Post />} />
         </Route>

--- a/src/components/Option/Option.jsx
+++ b/src/components/Option/Option.jsx
@@ -1,25 +1,19 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import selectIcon from '@/assets/icons/select.svg';
 import SelectIcon from '@/styles/button/SelectIcon';
 import { getBackgroundImages } from '@/api/backgroundImages';
 import useAsync from '@/hooks/useAsync';
 import {
-  OptionContainer,
   ButtonContainer,
   CardContainer,
+  CategoryButton,
   ColorChip,
   ImageChip,
-  CategoryButton,
+  OptionContainer,
 } from '@/components/Option/Option.style';
+import { BACKGROUND_COLORS } from '@/util/backgroundColors.jsx';
 
 const CATEGORIES = ['컬러', '이미지'];
-
-const BACKGROUND_COLORS = [
-  { name: 'beige', color: 'var(--orange-200, #FFE2AD)' },
-  { name: 'purple', color: 'var(--purple-200, #ECD9FF)' },
-  { name: 'blue', color: 'var(--blue-200, #B1E4FF)' },
-  { name: 'green', color: 'var(--green-200, #D0F5C3)' },
-];
 
 function Option({ setPostValue }) {
   const [isCategorySelect, setIsCategorySelect] = useState(0);

--- a/src/components/PaperCard/PaperCard.jsx
+++ b/src/components/PaperCard/PaperCard.jsx
@@ -1,25 +1,32 @@
 import styled from 'styled-components';
-import purplePatternImg from '@/assets/images/card_pattern_purple.png';
+import ProfileImageGroup from '@/styles/profileImage/ProfileImageGroup.jsx';
+import { FONT18B, FONT24B } from '@/styles/fontType.js';
+import Emoji from '@/components/Emoji/Emoji.jsx';
+import { BACKGROUND_COLOR_PALETTE } from '@/util/backgroundColors.jsx';
 
-// TODO : 작성자들에 아바타 컴포넌트 추가, 작성 인원 수 추가, 이모지 컴포넌트 추가, 컬러에 따라 카드배경색, 패턴 다르게 받기
+function PaperCard({ card }) {
+  const { name, backgroundColor, backgroundImageURL, messageCount, topReactions } = card;
+  const { recentMessages } = card;
+  const profileImages = recentMessages === 0 ? [] : recentMessages.map((message) => message.profileImageURL);
+  const reactions = [...topReactions].slice(0, 3);
+  const colorPalette = BACKGROUND_COLOR_PALETTE[backgroundColor];
 
-function PaperCard({ number }) {
   return (
-    <CardContainer>
-      <Recipient>{`To. 민혁 ${number}`}</Recipient>
-      <Writers>작성자들</Writers>
-      <WriterCounter>
-        <span>30</span>
-        명이 작성했어요!
-      </WriterCounter>
+    <CardContainer $backgroundColor={colorPalette.color} $imageUrl={backgroundImageURL}>
+      <CardInfo>
+        <Recipient>{`To. ${name}`}</Recipient>
+        <ProfileImageGroup profileImages={profileImages} />
+        <WriterCounter>
+          <span>{messageCount}</span>
+          명이 작성했어요!
+        </WriterCounter>
+      </CardInfo>
       <BottomContainer>
         <EmojiContainer>
-          <div>이모지1</div>
-          <div>이모지2</div>
-          <div>이모지3</div>
+          {reactions.length !== 0 && reactions.map((el) => <Emoji reaction={el} key={el.emoji} />)}
         </EmojiContainer>
       </BottomContainer>
-      <PatternImg src={purplePatternImg} />
+      <PatternImg src={colorPalette.pattern} $isImage={backgroundImageURL} />
     </CardContainer>
   );
 }
@@ -34,7 +41,10 @@ const CardContainer = styled.div`
   padding: 3rem 2.4rem 2rem;
   border-radius: 16px;
   border: 0.1rem solid rgba(0, 0, 0, 0.1);
-  background: var(--purple-200, #ecd9ff);
+  background: ${({ $backgroundColor, $imageUrl }) =>
+    ($imageUrl ? `url(${$imageUrl})` : `${$backgroundColor}`)};
+  background-size: cover;
+  background-repeat: no-repeat;
   box-shadow: 0 0.2rem 1.2rem 0 rgba(0, 0, 0, 0.08);
 
   @media (min-width: 768px) {
@@ -51,23 +61,18 @@ const Recipient = styled.h1`
   overflow: hidden;
   color: var(--gray-900, #181818);
   text-overflow: ellipsis;
-  font-size: 1.8rem;
-  font-weight: 700;
-  line-height: 2.8rem;
-  letter-spacing: -0.018rem;
+  ${FONT18B};
 
   @media (min-width: 768px) {
-    font-size: 2.4rem;
-    line-height: 3.6rem;
-    letter-spacing: -0.024px;
+    ${FONT24B};
   }
 `;
 
-const Writers = styled.div`
+const CardInfo = styled.div`
   display: flex;
   align-items: flex-start;
-  gap: -1.2rem;
-  margin: 1.2rem 0;
+  flex-direction: column;
+  gap: 1.2rem;
 `;
 
 const WriterCounter = styled.div`
@@ -116,6 +121,7 @@ const BottomContainer = styled.div`
 const EmojiContainer = styled.div`
   display: flex;
   align-items: flex-start;
+  z-index: 1;
   gap: 0.8rem;
 `;
 
@@ -127,6 +133,7 @@ const PatternImg = styled.img`
   height: 14.2rem;
   flex-shrink: 0;
   border-radius: 0 0 16px 0;
+  display: ${({ $isImage }) => ($isImage ? 'none' : 'static')};
 
   @media (min-width: 768px) {
     width: 14.2rem;

--- a/src/components/PaperCard/PaperCard.jsx
+++ b/src/components/PaperCard/PaperCard.jsx
@@ -133,7 +133,7 @@ const PatternImg = styled.img`
   height: 14.2rem;
   flex-shrink: 0;
   border-radius: 0 0 16px 0;
-  display: ${({ $isImage }) => ($isImage ? 'none' : 'static')};
+  display: ${({ $isImage }) => ($isImage ? 'none' : 'static')} !important;
 
   @media (min-width: 768px) {
     width: 14.2rem;

--- a/src/components/PaperCard/PaperCard.jsx
+++ b/src/components/PaperCard/PaperCard.jsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { Link } from 'react-router-dom';
 import ProfileImageGroup from '@/styles/profileImage/ProfileImageGroup.jsx';
 import { FONT18B, FONT24B } from '@/styles/fontType.js';
 import Emoji from '@/components/Emoji/Emoji.jsx';
@@ -12,22 +13,24 @@ function PaperCard({ card }) {
   const colorPalette = BACKGROUND_COLOR_PALETTE[backgroundColor];
 
   return (
-    <CardContainer $backgroundColor={colorPalette.color} $imageUrl={backgroundImageURL}>
-      <CardInfo>
-        <Recipient $isImage={backgroundImageURL} >{`To. ${name}`}</Recipient>
-        <ProfileImageGroup profileImages={profileImages} />
-        <WriterCounter $isImage={backgroundImageURL} >
-          <span>{messageCount}</span>
-          명이 작성했어요!
-        </WriterCounter>
-      </CardInfo>
-      <BottomContainer>
-        <EmojiContainer>
-          {reactions.length !== 0 && reactions.map((el) => <Emoji reaction={el} key={el.emoji} />)}
-        </EmojiContainer>
-      </BottomContainer>
-      <PatternImg src={colorPalette.pattern} $isImage={backgroundImageURL} />
-    </CardContainer>
+    <Link to={`/post/${card.id}`}>
+      <CardContainer $backgroundColor={colorPalette.color} $imageUrl={backgroundImageURL}>
+        <CardInfo>
+          <Recipient $isImage={backgroundImageURL}>{`To. ${name}`}</Recipient>
+          <ProfileImageGroup profileImages={profileImages} />
+          <WriterCounter $isImage={backgroundImageURL}>
+            <span>{messageCount}</span>
+            명이 작성했어요!
+          </WriterCounter>
+        </CardInfo>
+        <BottomContainer>
+          <EmojiContainer>
+            {reactions.length !== 0 && reactions.map((el) => <Emoji reaction={el} key={el.emoji} />)}
+          </EmojiContainer>
+        </BottomContainer>
+        <PatternImg src={colorPalette.pattern} $isImage={backgroundImageURL} />
+      </CardContainer>
+    </Link>
   );
 }
 
@@ -42,12 +45,13 @@ const CardContainer = styled.div`
   border-radius: 16px;
   border: 0.1rem solid rgba(0, 0, 0, 0.1);
   background: ${({ $backgroundColor, $imageUrl }) =>
-    ($imageUrl 
-            ? `linear-gradient(180deg, rgba(0, 0, 0, 0.54) 0%, rgba(0, 0, 0, 0.54) 100%), url(${$imageUrl})` 
-            : `${$backgroundColor}`)};
+          ($imageUrl
+                  ? `linear-gradient(180deg, rgba(0, 0, 0, 0.54) 0%, rgba(0, 0, 0, 0.54) 100%), url(${$imageUrl})`
+                  : `${$backgroundColor}`)};
   background-size: cover;
   background-repeat: no-repeat;
   box-shadow: 0 0.2rem 1.2rem 0 rgba(0, 0, 0, 0.08);
+  cursor: pointer;
 
   @media (min-width: 768px) {
     width: 27.5rem;

--- a/src/components/PaperCard/PaperCard.jsx
+++ b/src/components/PaperCard/PaperCard.jsx
@@ -14,9 +14,9 @@ function PaperCard({ card }) {
   return (
     <CardContainer $backgroundColor={colorPalette.color} $imageUrl={backgroundImageURL}>
       <CardInfo>
-        <Recipient>{`To. ${name}`}</Recipient>
+        <Recipient $isImage={backgroundImageURL} >{`To. ${name}`}</Recipient>
         <ProfileImageGroup profileImages={profileImages} />
-        <WriterCounter>
+        <WriterCounter $isImage={backgroundImageURL} >
           <span>{messageCount}</span>
           명이 작성했어요!
         </WriterCounter>
@@ -42,7 +42,7 @@ const CardContainer = styled.div`
   border-radius: 16px;
   border: 0.1rem solid rgba(0, 0, 0, 0.1);
   background: ${({ $backgroundColor, $imageUrl }) =>
-    ($imageUrl ? `url(${$imageUrl})` : `${$backgroundColor}`)};
+    ($imageUrl ? `linear-gradient(180deg, rgba(0, 0, 0, 0.54) 0%, rgba(0, 0, 0, 0.54) 100%), url(${$imageUrl})` : `${$backgroundColor}`)};
   background-size: cover;
   background-repeat: no-repeat;
   box-shadow: 0 0.2rem 1.2rem 0 rgba(0, 0, 0, 0.08);
@@ -59,7 +59,7 @@ const Recipient = styled.h1`
   -webkit-line-clamp: 1;
   align-self: stretch;
   overflow: hidden;
-  color: var(--gray-900, #181818);
+  color: ${({ $isImage }) => ($isImage ? 'var(--white, #fff)' : 'var(--gray-900, #181818)')};
   text-overflow: ellipsis;
   ${FONT18B};
 
@@ -76,14 +76,14 @@ const CardInfo = styled.div`
 `;
 
 const WriterCounter = styled.div`
-  color: var(--gray-700, #3a3a3a);
+  color: ${({ $isImage }) => ($isImage ? 'var(--grey-200, #eee)' : 'var(--gray-700, #3a3a3a)')};
 
   span {
     font-size: 1.4rem;
     font-weight: 700;
     line-height: 2rem;
     letter-spacing: -0.007rem;
-    color: var(--gray-700, #3a3a3a);
+    color: ${({ $isImage }) => ($isImage ? 'var(--grey-200, #eee)' : 'var(--gray-700, #3a3a3a)')};
   }
 
   font-size: 1.4rem;

--- a/src/components/PaperCard/PaperCard.jsx
+++ b/src/components/PaperCard/PaperCard.jsx
@@ -42,7 +42,9 @@ const CardContainer = styled.div`
   border-radius: 16px;
   border: 0.1rem solid rgba(0, 0, 0, 0.1);
   background: ${({ $backgroundColor, $imageUrl }) =>
-    ($imageUrl ? `linear-gradient(180deg, rgba(0, 0, 0, 0.54) 0%, rgba(0, 0, 0, 0.54) 100%), url(${$imageUrl})` : `${$backgroundColor}`)};
+    ($imageUrl 
+            ? `linear-gradient(180deg, rgba(0, 0, 0, 0.54) 0%, rgba(0, 0, 0, 0.54) 100%), url(${$imageUrl})` 
+            : `${$backgroundColor}`)};
   background-size: cover;
   background-repeat: no-repeat;
   box-shadow: 0 0.2rem 1.2rem 0 rgba(0, 0, 0, 0.08);

--- a/src/components/PaperCard/RollingPaperList.jsx
+++ b/src/components/PaperCard/RollingPaperList.jsx
@@ -73,6 +73,8 @@ const PaperListSlider = styled(Slider)`
     opacity: 0;
     display: none;
   }
+
+  padding-left: 2rem;
 `;
 
 const PaperListSlide = styled.div`

--- a/src/components/PaperCard/RollingPaperList.jsx
+++ b/src/components/PaperCard/RollingPaperList.jsx
@@ -35,37 +35,29 @@ function RollingPaperList({ paperCardList }) {
   }, []);
 
   return (
-    <Div>
-      <PaperListContainer>
-        {isGreaterPCWidth ? (
-          <PaperListSlider
-            {...settings}
-            prevArrow={<PrevArrow paperIndex={currentIndex} />}
-            nextArrow={<NextArrow paperIndex={currentIndex} length={paperCardList.length} />}
-          >
-            {paperCardList.map((num) => (
-              <PaperCard number={num} key={num} />
-            ))}
-          </PaperListSlider>
-        ) : (
-          <PaperListSlide>
-            {paperCardList.map((num) => (
-              <PaperCard number={num} key={num} />
-            ))}
-          </PaperListSlide>
-        )}
-      </PaperListContainer>
-    </Div>
+    <PaperListContainer>
+      {isGreaterPCWidth ? (
+        <PaperListSlider
+          {...settings}
+          prevArrow={<PrevArrow paperIndex={currentIndex} />}
+          nextArrow={<NextArrow paperIndex={currentIndex} length={paperCardList.length} />}
+        >
+          {paperCardList.map((num) => (
+            <PaperCard number={num} key={num} />
+          ))}
+        </PaperListSlider>
+      ) : (
+        <PaperListSlide>
+          {paperCardList.map((num) => (
+            <PaperCard number={num} key={num} />
+          ))}
+        </PaperListSlide>
+      )}
+    </PaperListContainer>
   );
 }
 
 export default RollingPaperList;
-
-const Div = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-`;
 
 const PaperListContainer = styled.div`
   width: 100%;

--- a/src/components/PaperCard/RollingPaperList.jsx
+++ b/src/components/PaperCard/RollingPaperList.jsx
@@ -42,14 +42,14 @@ function RollingPaperList({ paperCardList }) {
           prevArrow={<PrevArrow paperIndex={currentIndex} />}
           nextArrow={<NextArrow paperIndex={currentIndex} length={paperCardList.length} />}
         >
-          {paperCardList.map((num) => (
-            <PaperCard number={num} key={num} />
+          {paperCardList.map((card) => (
+            <PaperCard card={card} key={card.id} />
           ))}
         </PaperListSlider>
       ) : (
         <PaperListSlide>
-          {paperCardList.map((num) => (
-            <PaperCard number={num} key={num} />
+          {paperCardList.map((card) => (
+            <PaperCard card={card} key={card.id} />
           ))}
         </PaperListSlide>
       )}

--- a/src/pages/From.jsx
+++ b/src/pages/From.jsx
@@ -1,5 +1,5 @@
-function FromPage() {
+function From() {
   return <div>From 페이지입니다.</div>;
 }
 
-export default FromPage;
+export default From;

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -42,8 +42,7 @@ const Button = styled(PrimaryButton)`
 
   @media (min-width: 1248px) {
     width: 28rem;
-    margin: auto;
-    margin-top: 4.8rem;
+    margin: 4.8rem auto auto;
   }
 `;
 

--- a/src/pages/PaperList.jsx
+++ b/src/pages/PaperList.jsx
@@ -1,0 +1,58 @@
+import styled from 'styled-components';
+import RollingPaperList from '@/components/PaperCard/RollingPaperList.jsx';
+import { FONT20B } from '@/styles/fontType.js';
+import PrimaryButton from '@/styles/button/PrimaryButton.jsx';
+
+function PaperList() {
+  // TODO: 임시로 함
+  const paperCardList = [1, 2, 3, 4, 5, 6, 7, 8];
+
+  return (
+    <PaperListMain>
+      <PaperListContainer>
+        <PaperListTitle>인기 롤링 페이퍼 🔥</PaperListTitle>
+        <RollingPaperList paperCardList={paperCardList} />
+      </PaperListContainer>
+      <PaperListContainer style={{ marginTop: '7.4rem' }}>
+        <PaperListTitle>최근에 만든 롤링 페이퍼⭐️</PaperListTitle>
+        <RollingPaperList paperCardList={paperCardList} />
+      </PaperListContainer>
+      <ButtonContainer>
+        <Button $size="big">나도 만들어보기</Button>
+      </ButtonContainer>
+    </PaperListMain>
+  );
+}
+
+export default PaperList;
+
+const PaperListMain = styled.main``;
+
+const PaperListContainer = styled.section`
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  align-items: flex-start;
+  margin-top: 4rem;
+  gap: 1.2rem;
+`;
+
+const PaperListTitle = styled.h1`
+  ${FONT20B};
+  font-weight: 600;
+  margin-left: 2rem;
+`;
+
+const ButtonContainer = styled.div`
+  margin-top: 4.2rem;
+  padding: 2.4rem 2rem;
+`;
+
+const Button = styled(PrimaryButton)`
+  width: 100%;
+
+  @media (min-width: 1248px) {
+    width: 28rem;
+    margin: 4.8rem auto auto;
+  }
+`;

--- a/src/pages/PaperList.jsx
+++ b/src/pages/PaperList.jsx
@@ -1,21 +1,42 @@
 import styled from 'styled-components';
+import { useCallback, useEffect, useState } from 'react';
 import RollingPaperList from '@/components/PaperCard/RollingPaperList.jsx';
 import * as F from '@/styles/fontType.js';
 import PrimaryButton from '@/styles/button/PrimaryButton.jsx';
+import useAsync from '@/hooks/useAsync.js';
+import { getRecipients } from '@/api/recipients.js';
 
 function PaperList() {
-  // TODO: 임시로 함
-  const paperCardList = [1, 2, 3, 4, 5, 6, 7, 8];
+  const [likePaperCardList, setLikePaperCardList] = useState([]);
+  const [recentPaperCardList, setRecentPaperCardList] = useState([]);
+  const [getRecipientsIsLoading, getRecipientsError, getRecipientsAsync] = useAsync(getRecipients);
+
+  const handleLikeLoad = useCallback(async () => {
+    const result = await getRecipientsAsync({ sort: 'like' });
+    const likeCards = [...result.results];
+    setLikePaperCardList(likeCards);
+  }, [getRecipientsAsync]);
+
+  const handleRecentLoad = useCallback(async () => {
+    const result = await getRecipientsAsync({});
+    const recentCards = [...result.results];
+    setRecentPaperCardList(recentCards);
+  }, [getRecipientsAsync]);
+
+  useEffect(() => {
+    handleLikeLoad();
+    handleRecentLoad();
+  }, [handleLikeLoad, handleRecentLoad]);
 
   return (
     <PaperListMain>
       <PaperListContainer>
         <PaperListTitle>인기 롤링 페이퍼 🔥</PaperListTitle>
-        <RollingPaperList paperCardList={paperCardList} />
+        <RollingPaperList paperCardList={likePaperCardList} />
       </PaperListContainer>
       <PaperListContainer style={{ marginTop: '7.4rem' }}>
         <PaperListTitle>최근에 만든 롤링 페이퍼⭐️</PaperListTitle>
-        <RollingPaperList paperCardList={paperCardList} />
+        <RollingPaperList paperCardList={recentPaperCardList} />
       </PaperListContainer>
       <ButtonContainer>
         <Button $size="big">나도 만들어보기</Button>

--- a/src/pages/PaperList.jsx
+++ b/src/pages/PaperList.jsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import RollingPaperList from '@/components/PaperCard/RollingPaperList.jsx';
-import { FONT20B } from '@/styles/fontType.js';
+import * as F from '@/styles/fontType.js';
 import PrimaryButton from '@/styles/button/PrimaryButton.jsx';
 
 function PaperList() {
@@ -35,17 +35,30 @@ const PaperListContainer = styled.section`
   align-items: flex-start;
   margin-top: 4rem;
   gap: 1.2rem;
+
+  @media (min-width: 768px) {
+    margin-top: 5rem;
+  }
 `;
 
 const PaperListTitle = styled.h1`
-  ${FONT20B};
+  ${F.FONT20B};
   font-weight: 600;
   margin-left: 2rem;
+
+  @media (min-width: 768px) {
+    ${F.FONT24B};
+  }
 `;
 
 const ButtonContainer = styled.div`
   margin-top: 4.2rem;
   padding: 2.4rem 2rem;
+
+  @media (min-width: 768px) {
+    margin-top: 13.2rem;
+    padding: 2.4rem;
+  }
 `;
 
 const Button = styled(PrimaryButton)`

--- a/src/pages/PaperList.jsx
+++ b/src/pages/PaperList.jsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { useCallback, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import RollingPaperList from '@/components/PaperCard/RollingPaperList.jsx';
 import * as F from '@/styles/fontType.js';
 import PrimaryButton from '@/styles/button/PrimaryButton.jsx';
@@ -39,7 +40,9 @@ function PaperList() {
         <RollingPaperList paperCardList={recentPaperCardList} />
       </PaperListContainer>
       <ButtonContainer>
-        <Button $size="big">나도 만들어보기</Button>
+        <Link to='/post'>
+          <Button $size="big">나도 만들어보기</Button>
+        </Link>
       </ButtonContainer>
     </PaperListMain>
   );

--- a/src/pages/PaperList.jsx
+++ b/src/pages/PaperList.jsx
@@ -26,7 +26,17 @@ function PaperList() {
 
 export default PaperList;
 
-const PaperListMain = styled.main``;
+const PaperListMain = styled.main`
+  @media (min-width: 1248px) {
+    display: flex;
+    max-width: 120rem;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    margin: 0 auto;
+    position: relative;
+  }
+`;
 
 const PaperListContainer = styled.section`
   display: flex;
@@ -48,6 +58,7 @@ const PaperListTitle = styled.h1`
 
   @media (min-width: 768px) {
     ${F.FONT24B};
+    margin-left: 2.4rem;
   }
 `;
 
@@ -59,6 +70,15 @@ const ButtonContainer = styled.div`
     margin-top: 13.2rem;
     padding: 2.4rem;
   }
+
+  @media (min-width: 1248px) {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-top: 4rem;
+    position: relative;
+    left: -1.4rem;
+  }
 `;
 
 const Button = styled(PrimaryButton)`
@@ -66,6 +86,5 @@ const Button = styled(PrimaryButton)`
 
   @media (min-width: 1248px) {
     width: 28rem;
-    margin: 4.8rem auto auto;
   }
 `;

--- a/src/pages/PaperList.jsx
+++ b/src/pages/PaperList.jsx
@@ -40,7 +40,7 @@ function PaperList() {
         <RollingPaperList paperCardList={recentPaperCardList} />
       </PaperListContainer>
       <ButtonContainer>
-        <Link to='/post'>
+        <Link to="/post">
           <Button $size="big">나도 만들어보기</Button>
         </Link>
       </ButtonContainer>

--- a/src/styles/button/ArrowButton.jsx
+++ b/src/styles/button/ArrowButton.jsx
@@ -46,11 +46,11 @@ const ArrowImg = styled.img`
 `;
 
 const PrevButton = styled(ArrowButton)`
-  left: -1.9rem;
+  left: 0.1rem;
   display: ${({ $showPrev }) => ($showPrev ? 'flex' : 'none')};
 `;
 
 const NextButton = styled(ArrowButton)`
-  right: -0.4rem;
+  right: -1rem;
   display: ${({ $showNext }) => ($showNext ? 'flex' : 'none')};
 `;

--- a/src/styles/profileImage/ProfileImageGroup.jsx
+++ b/src/styles/profileImage/ProfileImageGroup.jsx
@@ -3,17 +3,18 @@ import ProfileImage, { ProfileImageContainer } from '@/styles/profileImage/Profi
 
 const PROFILE_SIZE = '2.8rem';
 
-function ProfileImageGroup({ profileImages }) {
+function ProfileImageGroup({ profileImages, messageCount = 0 }) {
   const lastOrder = profileImages.length;
 
   return (
     <ProfileImageGroupDiv>
       <ProfileImageGroupContainer>
-        {profileImages.map((image, index) => (
-          <ProfileImage profileImage={image} size={PROFILE_SIZE} order={index} key={index} />
-        ))}
+        {lastOrder !== 0
+          && profileImages.map((image, index) => (
+            <ProfileImage profileImage={image} size={PROFILE_SIZE} order={index} key={index} />
+          ))}
         <ProfileImageCounter $size={PROFILE_SIZE} $order={lastOrder}>
-          <ProfileCount>+6</ProfileCount>
+          <ProfileCount>+{messageCount}</ProfileCount>
         </ProfileImageCounter>
       </ProfileImageGroupContainer>
     </ProfileImageGroupDiv>
@@ -22,12 +23,13 @@ function ProfileImageGroup({ profileImages }) {
 
 export default ProfileImageGroup;
 
-const ProfileImageGroupContainer = styled.div`
-  position: relative;
-`;
-
 const ProfileImageGroupDiv = styled.div`
   width: 7.6rem;
+  height: 3rem;
+`;
+
+const ProfileImageGroupContainer = styled.div`
+  position: relative;
 `;
 
 const ProfileImageCounter = styled(ProfileImageContainer)`

--- a/src/util/backgroundColors.jsx
+++ b/src/util/backgroundColors.jsx
@@ -1,0 +1,11 @@
+import yellowPattern from '@/assets/images/card_pattern_yellow.png';
+import purplePattern from '@/assets/images/card_pattern_purple.png';
+import bluePattern from '@/assets/images/card_pattern_blue.png';
+import greenPattern from '@/assets/images/card_pattern_green.png';
+
+export const BACKGROUND_COLORS = [
+  { name: 'beige', color: 'var(--orange-200, #FFE2AD)', pattern: yellowPattern },
+  { name: 'purple', color: 'var(--purple-200, #ECD9FF)', pattern: purplePattern },
+  { name: 'blue', color: 'var(--blue-200, #B1E4FF)', pattern: bluePattern },
+  { name: 'green', color: 'var(--green-200, #D0F5C3)', pattern: greenPattern },
+];

--- a/src/util/backgroundColors.jsx
+++ b/src/util/backgroundColors.jsx
@@ -9,3 +9,22 @@ export const BACKGROUND_COLORS = [
   { name: 'blue', color: 'var(--blue-200, #B1E4FF)', pattern: bluePattern },
   { name: 'green', color: 'var(--green-200, #D0F5C3)', pattern: greenPattern },
 ];
+
+export const BACKGROUND_COLOR_PALETTE = {
+  beige: {
+    color: 'var(--orange-200, #FFE2AD)',
+    pattern: yellowPattern,
+  },
+  purple: {
+    color: 'var(--purple-200, #ECD9FF)',
+    pattern: purplePattern,
+  },
+  blue: {
+    color: 'var(--blue-200, #B1E4FF)',
+    pattern: bluePattern,
+  },
+  green: {
+    color: 'var(--green-200, #D0F5C3)',
+    pattern: greenPattern,
+  },
+};


### PR DESCRIPTION
## #60 closed #60 

## 구현 기능 및 변경 사항
-  구경해보기 클릭 → 리스트 페이지 이동
- 페이지 렌더링
- 인기 롤링 페이퍼 컴포넌트 만들기
-  최근에 만든 롤링 페이퍼 만들기
- 각 카드 클릭시 해당 id로 페이지 이동

## 스크린샷(선택)
![003](https://github.com/codeit-team8/rolling/assets/49144662/73b06077-1951-4c6f-8298-8bff11a45507)
