### PR TITLE
[#73]/edit 페이지로 이동하여 편집하기 보이는 페이지로 이동 , 휴지통 버튼을 누르면 삭제되고 카드 재정렬 

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import Nav from '@/components/Nav/Nav.jsx';
 import From from '@/pages/From.jsx';
 import PaperList from '@/pages/PaperList.jsx';
 import To from '@/pages/To.jsx';
+import Edit from '@/pages/Edit';
 import ErrorFallback from './Error/ErrorFallback';
 
 function App() {
@@ -22,6 +23,7 @@ function App() {
             <Route index element={<To />} />
             <Route path=":recipientId" element={<Post />} />
             <Route path=":recipientId/message" element={<From />} />
+            <Route path=":recipientId/edit" element={<Edit />} />
           </Route>
         </Routes>
       </ErrorBoundary>

--- a/src/components/MessageCard/MessageCard.jsx
+++ b/src/components/MessageCard/MessageCard.jsx
@@ -19,20 +19,20 @@ import {
 import deleteIcon from '@/assets/icons/deleted.svg';
 import { FONT_PALETTE } from '@/util/font.jsx';
 
-function MessageCard({ value, isEdit }) {
+function MessageCard({ value, isEdit, onDelete }) {
   const { id, profileImageURL, sender, relationship, content, font, createdAt } = value;
   const fontFamily = FONT_PALETTE[font];
 
-  const handleDelete = useCallback(async () => {
-    const deleteId = await deleteMessage({ messageId: id });
-  }, [id]);
+  // const handleDelete = useCallback(async () => {
+  //   const deleteId = await deleteMessage({ messageId: id });
+  // }, [id]);
 
   return (
     <MessageCardWrapper>
       <MessageCardTop>
         {isEdit && (
           <DeleteBox>
-            <DeleteImg src={deleteIcon} alt="메시지 카드 삭제 버튼" onClick={handleDelete} />
+            <DeleteImg src={deleteIcon} alt="메시지 카드 삭제 버튼" onClick={() => onDelete(id)} />
           </DeleteBox>
         )}
         <MessageCardProfile>

--- a/src/components/MessageCard/MessageCard.jsx
+++ b/src/components/MessageCard/MessageCard.jsx
@@ -1,4 +1,5 @@
-import { useLocation } from 'react-router-dom';
+import { useCallback } from 'react';
+import { deleteMessage } from '@/api/message';
 import Badge from '@/components/MessageCard/Badge.jsx';
 import {
   Author,
@@ -18,18 +19,20 @@ import {
 import deleteIcon from '@/assets/icons/deleted.svg';
 import { FONT_PALETTE } from '@/util/font.jsx';
 
-function MessageCard({ value }) {
-  const { profileImageURL, sender, relationship, content, font, createdAt } = value;
-  const location = useLocation();
-  const deleteBoxVisible = location.pathname === '/edit';
+function MessageCard({ value, isEdit }) {
+  const { id, profileImageURL, sender, relationship, content, font, createdAt } = value;
   const fontFamily = FONT_PALETTE[font];
+
+  const handleDelete = useCallback(async () => {
+    const deleteId = await deleteMessage({ messageId: id });
+  }, [id]);
 
   return (
     <MessageCardWrapper>
       <MessageCardTop>
-        {deleteBoxVisible && (
+        {isEdit && (
           <DeleteBox>
-            <DeleteImg src={deleteIcon} alt="메시지 카드 삭제 버튼" />
+            <DeleteImg src={deleteIcon} alt="메시지 카드 삭제 버튼" onClick={handleDelete} />
           </DeleteBox>
         )}
         <MessageCardProfile>

--- a/src/components/MessageCard/MessageCard.style.jsx
+++ b/src/components/MessageCard/MessageCard.style.jsx
@@ -47,6 +47,7 @@ export const DeleteBox = styled.div`
   border-radius: 6px;
   border: 1px solid var(--gray-300, #ccc);
   background: var(--white, #fff);
+  cursor: pointer;
 `;
 
 export const DeleteImg = styled.img`

--- a/src/pages/Edit.jsx
+++ b/src/pages/Edit.jsx
@@ -9,6 +9,7 @@ import PlusMessageCard from '@/components/MessageCard/PlusMessageCard';
 import MessageCard from '@/components/MessageCard/MessageCard';
 import { getRecipientsId } from '@/api/recipients';
 import { BACKGROUND_COLOR_PALETTE } from '@/util/backgroundColors.jsx';
+import { deleteMessage } from '@/api/message';
 
 function Edit() {
   const [isEdit, setIsEdit] = useState(false);
@@ -56,7 +57,10 @@ function Edit() {
     setProfileImages(recentPostProfileImages);
   };
 
-  const 
+  const onDelete = useCallback(async (messageId) => {
+    await deleteMessage({ messageId });
+    setMessageContents((prevMessages) => prevMessages.filter((message) => message.id !== messageId));
+  });
 
   return (
     <>
@@ -72,7 +76,12 @@ function Edit() {
           {!isEdit && <PlusMessageCard />}
           {messageContents &&
             messageContents.map((messageCard) => (
-              <MessageCard value={messageCard} key={messageCard.id} isEdit={isEdit} />
+              <MessageCard
+                value={messageCard}
+                key={messageCard.id}
+                isEdit={isEdit}
+                onDelete={() => onDelete(messageCard.id)}
+              />
             ))}
         </CardContainer>
         {isEdit && (

--- a/src/pages/Edit.jsx
+++ b/src/pages/Edit.jsx
@@ -10,86 +10,22 @@ import MessageCard from '@/components/MessageCard/MessageCard';
 import { getRecipientsId } from '@/api/recipients';
 import { BACKGROUND_COLOR_PALETTE } from '@/util/backgroundColors.jsx';
 import { deleteMessage } from '@/api/message';
+import Post from './Post';
 
 function Edit() {
-  const [isEdit, setIsEdit] = useState(false);
-  const handleEditClick = () => {
-    if (isEdit) {
-      console.log('true상태!!');
-    } else {
-      console.log('false상태!!');
-    }
-    setIsEdit(!isEdit);
-  };
-
-  const [postName, setPostName] = useState('');
-  const [postMessageCount, setPostMessageCount] = useState(0);
-  const [reactions, setReactions] = useState([]);
-  const [profileImages, setProfileImages] = useState([]);
-
-  const [messageContents, setMessageContents] = useState();
-  const [background, setBackground] = useState('var(--orange-200, #ffe2ad)');
-
-  const { recipientId } = useParams();
-
-  const handleRollingPaper = useCallback(async () => {
-    const results = await getRecipientsId({ id: recipientId });
-    const { name, messageCount, backgroundColor, backgroundImageURL, topReactions } = { ...results };
-    const { color } = BACKGROUND_COLOR_PALETTE[backgroundColor];
-    const recentMessages = [...results.recentMessages];
-
-    handlePostHeader(name, messageCount, topReactions, recentMessages);
-
-    setMessageContents(recentMessages);
-    setBackground({ color, backgroundImageURL });
-  }, [recipientId]);
-
-  useEffect(() => {
-    handleRollingPaper();
-  }, [handleRollingPaper]);
-
-  const handlePostHeader = (name, messageCount, topReactions, recentMessages) => {
-    setPostName(name);
-    setPostMessageCount(messageCount);
-    setReactions([...topReactions].slice(0, 3));
-    const recentPostProfileImages =
-      recentMessages.length === 0 ? [] : recentMessages.map((message) => message.profileImageURL).slice(0, 3);
-    setProfileImages(recentPostProfileImages);
-  };
-
-  const onDelete = useCallback(async (messageId) => {
-    await deleteMessage({ messageId });
-    setMessageContents((prevMessages) => prevMessages.filter((message) => message.id !== messageId));
-  });
+  // const [isEdit, setIsEdit] = useState(false);
+  // const handleEditClick = () => {
+  //   if (isEdit) {
+  //     console.log('true상태!!');
+  //   } else {
+  //     console.log('false상태!!');
+  //   }
+  //   setIsEdit(!isEdit);
+  // };
 
   return (
     <>
-      <PostHeader name={postName} messageCount={postMessageCount} reactions={reactions} profileImages={profileImages} />
-      <PostContainer $backgroundColor={background.color} $imageUrl={background.backgroundImageURL}>
-        {!isEdit && (
-          <EditButton $size="H40" type="button" onClick={handleEditClick}>
-            편집하기
-          </EditButton>
-        )}
-
-        <CardContainer>
-          {!isEdit && <PlusMessageCard />}
-          {messageContents &&
-            messageContents.map((messageCard) => (
-              <MessageCard
-                value={messageCard}
-                key={messageCard.id}
-                isEdit={isEdit}
-                onDelete={() => onDelete(messageCard.id)}
-              />
-            ))}
-        </CardContainer>
-        {isEdit && (
-          <SaveButtonContainer>
-            <SaveButton $size="big">저장하기</SaveButton>
-          </SaveButtonContainer>
-        )}
-      </PostContainer>
+      <Post />
     </>
   );
 }
@@ -164,36 +100,4 @@ const PostContainer = styled.div`
     grid-template-columns: repeat(3, 38.4rem);
     grid-template-rows: repeat(auto-fit, 28rem);
   }
-`;
-
-const SaveButtonContainer = styled.div`
-  bottom: 2.4rem;
-  position: absolute;
-  margin-top: 4.2rem;
-  padding: 2.4rem 2rem;
-  background-color: @media (min-width: 768px) {
-    margin-top: 13.2rem;
-    padding: 2.4rem;
-  }
-
-  @media (min-width: 1248px) {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    margin-top: 4rem;
-  }
-`;
-
-const SaveButton = styled(PrimaryButton)`
-  width: 100%;
-
-  @media (min-width: 1248px) {
-    width: 28rem;
-  }
-`;
-
-const EditButton = styled(OutlineButton)`
-  display: flex;
-  border-radius: 8px;
-  font-size: 1.6rem;
 `;

--- a/src/pages/Edit.jsx
+++ b/src/pages/Edit.jsx
@@ -1,3 +1,6 @@
+import React from 'react';
+import PrimaryButton from '@/styles/button/PrimaryButton.jsx';
+import OutlineButton from '@/styles/button/OutlineButton.jsx';
 import { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
@@ -7,7 +10,17 @@ import MessageCard from '@/components/MessageCard/MessageCard';
 import { getRecipientsId } from '@/api/recipients';
 import { BACKGROUND_COLOR_PALETTE } from '@/util/backgroundColors.jsx';
 
-function Post() {
+function Edit() {
+  const [isEdit, setIsEdit] = useState(false);
+  const handleEditClick = () => {
+    if (isEdit) {
+      console.log('true상태!!');
+    } else {
+      console.log('false상태!!');
+    }
+    setIsEdit(!isEdit);
+  };
+
   const [postName, setPostName] = useState('');
   const [postMessageCount, setPostMessageCount] = useState(0);
   const [reactions, setReactions] = useState([]);
@@ -43,21 +56,38 @@ function Post() {
     setProfileImages(recentPostProfileImages);
   };
 
+  const 
+
   return (
     <>
       <PostHeader name={postName} messageCount={postMessageCount} reactions={reactions} profileImages={profileImages} />
       <PostContainer $backgroundColor={background.color} $imageUrl={background.backgroundImageURL}>
-        <PlusMessageCard />
-        {messageContents &&
-          messageContents.map((messageCard) => <MessageCard value={messageCard} key={messageCard.id} />)}
+        {!isEdit && (
+          <EditButton $size="H40" type="button" onClick={handleEditClick}>
+            편집하기
+          </EditButton>
+        )}
+
+        <CardContainer>
+          {!isEdit && <PlusMessageCard />}
+          {messageContents &&
+            messageContents.map((messageCard) => (
+              <MessageCard value={messageCard} key={messageCard.id} isEdit={isEdit} />
+            ))}
+        </CardContainer>
+        {isEdit && (
+          <SaveButtonContainer>
+            <SaveButton $size="big">저장하기</SaveButton>
+          </SaveButtonContainer>
+        )}
       </PostContainer>
     </>
   );
 }
 
-export default Post;
+export default Edit;
 
-const PostContainer = styled.div`
+const CardContainer = styled.div`
   padding: 4.2rem 2rem 0;
   display: grid;
   grid-template-columns: repeat(1, 32rem);
@@ -66,14 +96,7 @@ const PostContainer = styled.div`
   gap: 2.4rem;
   margin: 0 auto;
   align-items: center;
-  height: 100vh;
-  background: ${({ $backgroundColor, $imageUrl }) =>
-    $imageUrl
-      ? `linear-gradient(180deg, rgba(0, 0, 0, 0.54) 0%, rgba(0, 0, 0, 0.54) 100%), url(${$imageUrl})`
-      : `${$backgroundColor}`};
-  background-size: cover;
-  background-position: center;
-  background-attachment: fixed;
+
   overflow: scroll;
   -ms-overflow-style: none; /* 인터넷 익스플로러 */
   scrollbar-width: none;
@@ -95,4 +118,73 @@ const PostContainer = styled.div`
     grid-template-columns: repeat(3, 38.4rem);
     grid-template-rows: repeat(auto-fit, 28rem);
   }
+`;
+
+const PostContainer = styled.div`
+  padding: 4.2rem 2rem 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 2.4rem;
+  margin: 0 auto;
+  align-items: center;
+  height: 100vh;
+  background: ${({ $backgroundColor, $imageUrl }) =>
+    $imageUrl
+      ? `linear-gradient(180deg, rgba(0, 0, 0, 0.54) 0%, rgba(0, 0, 0, 0.54) 100%), url(${$imageUrl})`
+      : `${$backgroundColor}`};
+  background-size: cover;
+  background-position: center;
+  background-attachment: fixed;
+  overflow: scroll;
+  -ms-overflow-style: none; /* 인터넷 익스플로러 */
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  @media (min-width: 768px) {
+    gap: 3rem;
+    padding: 4.9rem 2.4rem;
+    height: 120rem;
+  }
+
+  @media (min-width: 1248px) {
+    padding: 6rem 2.4rem;
+    grid-template-columns: repeat(3, 38.4rem);
+    grid-template-rows: repeat(auto-fit, 28rem);
+  }
+`;
+
+const SaveButtonContainer = styled.div`
+  bottom: 2.4rem;
+  position: absolute;
+  margin-top: 4.2rem;
+  padding: 2.4rem 2rem;
+  background-color: @media (min-width: 768px) {
+    margin-top: 13.2rem;
+    padding: 2.4rem;
+  }
+
+  @media (min-width: 1248px) {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-top: 4rem;
+  }
+`;
+
+const SaveButton = styled(PrimaryButton)`
+  width: 100%;
+
+  @media (min-width: 1248px) {
+    width: 28rem;
+  }
+`;
+
+const EditButton = styled(OutlineButton)`
+  display: flex;
+  border-radius: 8px;
+  font-size: 1.6rem;
 `;

--- a/src/pages/Post.jsx
+++ b/src/pages/Post.jsx
@@ -67,33 +67,45 @@ function Post() {
   return (
     <>
       <PostHeader name={postName} messageCount={postMessageCount} reactions={reactions} profileImages={profileImages} />
-      {EditPage && !isEdit && (
-        <EditButton $size="H40" type="button" onClick={handleEditClick}>
-          편집하기
-        </EditButton>
-      )}
-      <PostContainer $backgroundColor={background.color} $imageUrl={background.backgroundImageURL}>
-        {!isEdit && <PlusMessageCard />}
-        {messageContents &&
-          messageContents.map((messageCard) => (
-            <MessageCard
-              value={messageCard}
-              key={messageCard.id}
-              isEdit={isEdit}
-              onDelete={() => onDelete(messageCard.id)}
-            />
-          ))}
-      </PostContainer>
-      {isEdit && (
-        <SaveButtonContainer>
-          <SaveButton $size="big">삭제하기</SaveButton>
-        </SaveButtonContainer>
-      )}
+      <PostBackground $backgroundColor={background.color} $imageUrl={background.backgroundImageURL}>
+        {EditPage && !isEdit && (
+          <EditButton $size="H40" type="button" onClick={handleEditClick}>
+            편집하기
+          </EditButton>
+        )}
+        <PostContainer>
+          {!isEdit && <PlusMessageCard />}
+          {messageContents &&
+            messageContents.map((messageCard) => (
+              <MessageCard
+                value={messageCard}
+                key={messageCard.id}
+                isEdit={isEdit}
+                onDelete={() => onDelete(messageCard.id)}
+              />
+            ))}
+        </PostContainer>
+        {isEdit && (
+          <SaveButtonContainer>
+            <SaveButton $size="big">삭제하기</SaveButton>
+          </SaveButtonContainer>
+        )}
+      </PostBackground>
     </>
   );
 }
 
 export default Post;
+
+const PostBackground = styled.div`
+  background: ${({ $backgroundColor, $imageUrl }) =>
+    $imageUrl
+      ? `linear-gradient(180deg, rgba(0, 0, 0, 0.54) 0%, rgba(0, 0, 0, 0.54) 100%), url(${$imageUrl})`
+      : `${$backgroundColor}`};
+  background-size: cover;
+  background-position: center;
+  background-attachment: fixed;
+`;
 
 const PostContainer = styled.div`
   padding: 4.2rem 2rem 0;
@@ -105,13 +117,7 @@ const PostContainer = styled.div`
   margin: 0 auto;
   align-items: center;
   height: 100vh;
-  background: ${({ $backgroundColor, $imageUrl }) =>
-    $imageUrl
-      ? `linear-gradient(180deg, rgba(0, 0, 0, 0.54) 0%, rgba(0, 0, 0, 0.54) 100%), url(${$imageUrl})`
-      : `${$backgroundColor}`};
-  background-size: cover;
-  background-position: center;
-  background-attachment: fixed;
+
   overflow: scroll;
   -ms-overflow-style: none; /* 인터넷 익스플로러 */
   scrollbar-width: none;

--- a/src/pages/Post.jsx
+++ b/src/pages/Post.jsx
@@ -1,13 +1,29 @@
 import { useCallback, useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import PostHeader from '@/components/Header/PostHeader.jsx';
 import PlusMessageCard from '@/components/MessageCard/PlusMessageCard';
 import MessageCard from '@/components/MessageCard/MessageCard';
 import { getRecipientsId } from '@/api/recipients';
 import { BACKGROUND_COLOR_PALETTE } from '@/util/backgroundColors.jsx';
+import { deleteMessage } from '@/api/message';
+import PrimaryButton from '@/styles/button/PrimaryButton.jsx';
+import OutlineButton from '@/styles/button/OutlineButton.jsx';
 
 function Post() {
+  const location = useLocation();
+  const EditPage = location.pathname.includes('/edit');
+
+  const [isEdit, setIsEdit] = useState(false);
+  const handleEditClick = () => {
+    if (isEdit) {
+      console.log('true상태!!');
+    } else {
+      console.log('false상태!!');
+    }
+    setIsEdit(!isEdit);
+  };
+
   const [postName, setPostName] = useState('');
   const [postMessageCount, setPostMessageCount] = useState(0);
   const [reactions, setReactions] = useState([]);
@@ -43,14 +59,36 @@ function Post() {
     setProfileImages(recentPostProfileImages);
   };
 
+  const onDelete = useCallback(async (messageId) => {
+    await deleteMessage({ messageId });
+    setMessageContents((prevMessages) => prevMessages.filter((message) => message.id !== messageId));
+  });
+
   return (
     <>
       <PostHeader name={postName} messageCount={postMessageCount} reactions={reactions} profileImages={profileImages} />
+      {EditPage && !isEdit && (
+        <EditButton $size="H40" type="button" onClick={handleEditClick}>
+          편집하기
+        </EditButton>
+      )}
       <PostContainer $backgroundColor={background.color} $imageUrl={background.backgroundImageURL}>
-        <PlusMessageCard />
+        {!isEdit && <PlusMessageCard />}
         {messageContents &&
-          messageContents.map((messageCard) => <MessageCard value={messageCard} key={messageCard.id} />)}
+          messageContents.map((messageCard) => (
+            <MessageCard
+              value={messageCard}
+              key={messageCard.id}
+              isEdit={isEdit}
+              onDelete={() => onDelete(messageCard.id)}
+            />
+          ))}
       </PostContainer>
+      {isEdit && (
+        <SaveButtonContainer>
+          <SaveButton $size="big">삭제하기</SaveButton>
+        </SaveButtonContainer>
+      )}
     </>
   );
 }
@@ -95,4 +133,35 @@ const PostContainer = styled.div`
     grid-template-columns: repeat(3, 38.4rem);
     grid-template-rows: repeat(auto-fit, 28rem);
   }
+`;
+const SaveButtonContainer = styled.div`
+  bottom: 2.4rem;
+  position: absolute;
+  margin-top: 4.2rem;
+  padding: 2.4rem 2rem;
+  background-color: @media (min-width: 768px) {
+    margin-top: 13.2rem;
+    padding: 2.4rem;
+  }
+
+  @media (min-width: 1248px) {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-top: 4rem;
+  }
+`;
+
+const SaveButton = styled(PrimaryButton)`
+  width: 100%;
+
+  @media (min-width: 1248px) {
+    width: 28rem;
+  }
+`;
+
+const EditButton = styled(OutlineButton)`
+  display: flex;
+  border-radius: 8px;
+  font-size: 1.6rem;
 `;

--- a/src/pages/Post.jsx
+++ b/src/pages/Post.jsx
@@ -167,7 +167,20 @@ const SaveButton = styled(PrimaryButton)`
 `;
 
 const EditButton = styled(OutlineButton)`
+  position: absolute;
+  right: 20px;
+  top: 128px;
   display: flex;
   border-radius: 8px;
   font-size: 1.6rem;
+
+  @media (min-width: 768px) {
+    right: 24px;
+    top: 172px;
+  }
+
+  @media (min-width: 1248px) {
+    right: 196px;
+    top: 360px;
+  }
 `;


### PR DESCRIPTION
## 관련 이슈
#73 

## 구현 기능 및 변경 사항
- [x]  URL → `domain/id/edit` 이동하기 구현
    - [ ]  심화: 버튼으로 edit 페이지로 이동 → 가장 후순위
- [x]  편집하기 페이지로 갔을 때 편집하기 버튼 생성
- [ ]  무한 스크롤 → 혜지님 
- [x]  편집하기 버튼 눌렀을 경우 편집하기 버튼, `+` 버튼 사라지고 롤링 페이퍼 카드 우측 상단에 휴지통 버튼, 저장하기 버튼 추가
- [x]  휴지통 버튼을 클릭하면 해당 카드를 삭제하고 카드 재정렬


##해야하는 것
- [ ] 피그마 디자인에 맞게 각 버튼의 위치, 사이즈 조절하기

## 스크린샷(선택)
