### PR TITLE
[#132] Post 페이지의 메세지 무한 스크롤 경우 맨 밑 여유공간 추가

### DIFF
--- a/src/pages/Post.style.jsx
+++ b/src/pages/Post.style.jsx
@@ -27,7 +27,7 @@ export const PostContainer = styled.div`
   grid-template-rows: repeat(auto-fit, 23rem);
   justify-content: center;
   gap: 2.4rem;
-  margin: 2.4rem auto 0 auto;
+  margin: 2.4rem auto 2.5rem auto;
   align-items: center;
   height: 100vh;
   overflow: scroll;


### PR DESCRIPTION
## #132 closed #132 

## 구현 기능 및 변경 사항
- Grid Container margin-bottom 2.5rem 추가 

## 스크린샷(선택)
<img width="537" alt="image" src="https://github.com/codeit-team8/rolling/assets/49144662/81da7dfe-cbd7-4d39-9f9d-8f2010a32fb0">
